### PR TITLE
Refactor logic between row_names from SE and row/column data

### DIFF
--- a/src/summarizedexperiment/BaseSE.py
+++ b/src/summarizedexperiment/BaseSE.py
@@ -436,7 +436,7 @@ class BaseSE:
         _row_copy = self._rows.copy()
 
         if replace_row_names:
-            _row_copy.row_names = self._row_names
+            return _row_copy.set_row_names(self._row_names, in_place=False)
 
         return _row_copy
 
@@ -472,8 +472,10 @@ class BaseSE:
 
         output = self._define_output(in_place)
         output._rows = rows
+
         if replace_row_names:
-            output._row_names = rows._row_names
+            return output.set_row_names(rows._row_names, in_place=False)
+
         return output
 
     @property
@@ -530,7 +532,7 @@ class BaseSE:
         _col_copy = self._cols.copy()
 
         if replace_row_names:
-            _col_copy.row_names = self._column_names
+            return _col_copy.set_row_names(self._column_names, in_place=False)
 
         return _col_copy
 
@@ -566,8 +568,10 @@ class BaseSE:
 
         output = self._define_output(in_place)
         output._cols = cols
+
         if replace_column_names:
-            output._column_names = cols.row_names
+            return output.set_column_names(cols.row_names, in_place=False)
+
         return output
 
     @property

--- a/src/summarizedexperiment/BaseSE.py
+++ b/src/summarizedexperiment/BaseSE.py
@@ -117,8 +117,8 @@ def _validate_metadata(metadata):
 
 
 class BaseSE:
-    """Base class for ``SummarizedExperiment``. This class provides common
-    properties and methods that can be utilized across all derived classes.
+    """Base class for ``SummarizedExperiment``. This class provides common properties and methods that can be utilized
+    across all derived classes.
 
     This container represents genomic experiment data in the form of
     ``assays``, features in ``row_data``, sample data in ``column_data``,
@@ -421,8 +421,7 @@ class BaseSE:
     ##########################
 
     def get_row_data(self, replace_row_names: bool = True) -> biocframe.BiocFrame:
-        """Get features, the `row_names` of row_data are replaced by the row_names
-        from the experiment.
+        """Get features, the `row_names` of row_data are replaced by the row_names from the experiment.
 
         Args:
             replace_row_names:

--- a/src/summarizedexperiment/RangedSummarizedExperiment.py
+++ b/src/summarizedexperiment/RangedSummarizedExperiment.py
@@ -142,10 +142,20 @@ class RangedSummarizedExperiment(SummarizedExperiment):
                 :py:class:`~biocframe.BiocFrame.BiocFrame`. Defaults to None.
 
             row_names:
-                A list of strings, same as the number of rows.Defaults to None.
+                A list of strings, same as the number of rows.
+
+                If ``row_names`` are not provided, these are inferred from
+                ``row_data``.
+
+                Defaults to None.
 
             column_names:
-                A list of string, same as the number of columns. Defaults to None.
+                A list of string, same as the number of columns.
+
+                if ``column_names`` are not provided, these are inferred from
+                ``column_data``.
+
+                Defaults to None.
 
             metadata:
                 Additional experimental metadata describing the methods.

--- a/src/summarizedexperiment/SummarizedExperiment.py
+++ b/src/summarizedexperiment/SummarizedExperiment.py
@@ -66,10 +66,20 @@ class SummarizedExperiment(BaseSE):
                 :py:class:`~biocframe.BiocFrame.BiocFrame`. Defaults to None.
 
             row_names:
-                A list of strings, same as the number of rows.Defaults to None.
+                A list of strings, same as the number of rows.
+
+                If ``row_names`` are not provided, these are inferred from
+                ``row_data``.
+
+                Defaults to None.
 
             column_names:
-                A list of string, same as the number of columns. Defaults to None.
+                A list of string, same as the number of columns.
+
+                if ``column_names`` are not provided, these are inferred from
+                ``column_data``.
+
+                Defaults to None.
 
             metadata:
                 Additional experimental metadata describing the methods.

--- a/tests/test_RSE_methods.py
+++ b/tests/test_RSE_methods.py
@@ -73,7 +73,7 @@ def test_RSE_props():
     assert tse.width is not None
 
     assert tse.rownames is None
-    assert tse.colnames is None
+    assert tse.colnames is not None
 
 
 def test_RSE_subset():

--- a/tests/test_SE.py
+++ b/tests/test_SE.py
@@ -57,7 +57,7 @@ def test_SE_init():
     assert tse.col_data is not None
     assert isinstance(tse.col_data, BiocFrame)
     assert tse.row_names is None
-    assert tse.col_names is None
+    assert tse.col_names is not None
 
 
 def test_SE_with_df():


### PR DESCRIPTION
- On construction, if `row_names` or `column_names` are not provided, these are automatically inferred from `row_data` and `column_data` objects. 
- On extraction of these objects, the row_names in row_data and column_data are replaced by the equivalents from the SE level. 
- On setting these objects, especially with the functional style (`set_row_data` and `set_column_data` methods), additional options are available to replace the names in the SE object. 